### PR TITLE
Address error when formatting multi-line strings

### DIFF
--- a/lib/fstrings/parser.rb
+++ b/lib/fstrings/parser.rb
@@ -43,7 +43,7 @@ module FStrings
       private
 
       def scan_simple(scan)
-        str = scan.scan_until(/\{|$/)
+        str = scan.scan_until(/\{|\z/)
         if scan.peek(1) == '{'
           str + scan.scan(/\{/) + scan_simple(scan)
         else

--- a/spec/fstrings_spec.rb
+++ b/spec/fstrings_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe FStrings do
 
   its_call('simple') { is_expected.to ret 'simple' }
   its_call('{{escaped}}') { is_expected.to ret '{{escaped}}' }
-  its_call('this is {int}') { is_expected.to ret 'this is 5' }
+  its_call("this is {int}") { is_expected.to ret "this is 5" }
   its_call('this is {str}') { is_expected.to ret 'this is string' }
   its_call('this is {str%p}') { is_expected.to ret 'this is "string"' }
+  its_call("this is {str}\n\nthis is {int}") { is_expected.to ret "this is string\n\nthis is 5" }
 
   its_call('this is {int%+i}') { is_expected.to ret 'this is +5' }
   its_call('this is {str% 16s}') { is_expected.to ret 'this is           string' }


### PR DESCRIPTION
Because the regexp searching for the next '{' needs to detect when there are no additional '{' remaining in the string it doesn't just search for '{'.  It needs to search for the end of the string as well.  Currently that regular expression is using the end of line matcher for that purpose.

That works fine...if the string is a single line.  But for a multi-line string with a line break after the last evaluated expression this fails with an error (the exact error depending on the parsing state).

The solution is to change the end-of-line matcher to the an end-of-string matcher, which is basically the intention anyway.

This PR makes that change and adds a test case.  Runs green locally.